### PR TITLE
Fix the text area so that it updates properly, remove links to some pages and remove a bunch of Netrunner references

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,13 +10,13 @@
     <link rel="stylesheet" href="css/style.css">
     <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
     <link rel="icon" href="favicon.ico" type="image/x-icon">
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-137348308-1"></script>
+    <!-- <script async src="https://www.googletagmanager.com/gtag/js?id=UA-137348308-1"></script>
     <script>
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
         gtag('config', 'UA-137348308-1');
-    </script>
+    </script> -->
 </head>
 <body>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js" integrity="sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf" crossorigin="anonymous"></script>
@@ -26,13 +26,13 @@
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="staticBackdropLabel">Welcome to Proxy Nexus!</h5>
+                    <h5 class="modal-title" id="staticBackdropLabel">Welcome to Proxy Raven!</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
                     <div>
                         <p>
-                            Here you can make high quality Netrunner proxies. Check out the instructions page for a detailed guide on how to use this website.
+                            Here you can make high quality Game of Thrones 2.0 proxies. Check out the instructions page for a detailed guide on how to use this website.
                         </p>
                         <p>
                             For those who've been here before, a bunch of options have been moved to the settings page. You can also view recent downloads on the new statistics page.
@@ -65,18 +65,18 @@
                     <li class="nav-item">
                         <a class="nav-link" href="instructions.html">Instructions</a>
                     </li>
-                    <li class="nav-item">
+                    <!-- <li class="nav-item">
                         <a class="nav-link" href="statistics.html">Statistics</a>
-                    </li>
+                    </li> -->
                     <!-- <li class="nav-item">
                         <a class="nav-link" href="blog.html">Blog</a>
                     </li> -->
-                    <li class="nav-item">
+                    <!-- <li class="nav-item">
                         <a class="nav-link" href="about.html">About</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link" href="settings.html">Settings</a>
-                    </li>
+                    </li> -->
                 </ul>
             </div>
         </div>
@@ -96,7 +96,7 @@
                     <div class="nav nav-tabs nav-fill" id="nav-tab" role="tablist">
                         <button class="nav-link active" id="nav-cardlist-tab" data-bs-toggle="tab" data-bs-target="#nav-cardlist" type="button" role="tab" aria-controls="nav-cardlist" aria-selected="true">Card List</button>
                         <button class="nav-link" id="nav-set-tab" data-bs-toggle="tab" data-bs-target="#nav-set" type="button" role="tab" aria-controls="nav-profile" aria-selected="false">Set</button>
-                        <button class="nav-link" id="nav-ndrb-tab" data-bs-toggle="tab" data-bs-target="#nav-ndrb" type="button" role="tab" aria-controls="nav-ndrb" aria-selected="false">Decklist</button>
+                        <!-- <button class="nav-link" id="nav-ndrb-tab" data-bs-toggle="tab" data-bs-target="#nav-ndrb" type="button" role="tab" aria-controls="nav-ndrb" aria-selected="false">Decklist</button> -->
                     </div>
                 </nav>
                 <div class="tab-content" id="nav-tabContent">

--- a/public/instructions.html
+++ b/public/instructions.html
@@ -10,13 +10,13 @@
     <link rel="stylesheet" href="css/style.css">
     <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
     <link rel="icon" href="favicon.ico" type="image/x-icon">
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-137348308-1"></script>
+    <!-- <script async src="https://www.googletagmanager.com/gtag/js?id=UA-137348308-1"></script>
     <script>
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
         gtag('config', 'UA-137348308-1');
-    </script>
+    </script> -->
 </head>
 <body>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js" integrity="sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf" crossorigin="anonymous"></script>
@@ -37,18 +37,18 @@
                     <li class="nav-item">
                         <a class="nav-link disabled" href="instructions.html">Instructions</a>
                     </li>
-                    <li class="nav-item">
+                    <!-- <li class="nav-item">
                         <a class="nav-link" href="statistics.html">Statistics</a>
-                    </li>
+                    </li> -->
                     <!-- <li class="nav-item">
                         <a class="nav-link" href="blog.html">Blog</a>
                     </li> -->
-                    <li class="nav-item">
+                    <!-- <li class="nav-item">
                         <a class="nav-link" href="about.html">About</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link" href="settings.html">Settings</a>
-                    </li>
+                    </li> -->
                 </ul>
             </div>
         </div>
@@ -58,7 +58,7 @@
             <div class="col-lg-12">
                 <h1>Instructions</h1>
                 <p>
-                    Proxy Nexus provides two methods of making Netrunner Proxies, paper proxies and printed cards at makeplayingcards.com.
+                    Proxy Raven provides two methods of making proxies, paper proxies and printed cards at makeplayingcards.com.
                 </p>
                 <h4>Paper Proxies</h4>
                 <p>
@@ -79,58 +79,16 @@
                     There are two caveats with this option.
                     <ul>
                         <li>
-                            Original netrunner cards are slightly narrower than the closest size card size MPC offers.
+                            Original cards are slightly narrower than the closest size card size MPC offers.
                         </li>
                         <li>
                             MPC expects images files to have a bleed around the edge of the card, since the cutting process has an amount of tolerance. Scans of physical cards don't have a bleed, so one must be added.
                         </li>
                     </ul>
                 </div>
-                <p>
-                    Proxy Nexus now supports multiple scan sources, with different ways to mitigate these limitations. If you'd like to read up on the details, check out the sections below.
-                </p>
-                <div class="accordion" id="accordionFlushExample">
-                    <div class="accordion-item">
-                        <h2 class="accordion-header" id="flush-headingOne">
-                            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#flush-collapseOne" aria-expanded="false" aria-controls="flush-collapseOne">
-                                New Scans from /u/PopTartNZ
-                            </button>
-                        </h2>
-                        <div id="flush-collapseOne" class="accordion-collapse collapse" aria-labelledby="flush-headingOne" data-bs-parent="#accordionFlushExample">
-                            <div class="accordion-body">
-                                The new scans use a dynamically generated bleed border, added using opencv.
-                                <strong>More info coming soon!</strong>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="accordion-item">
-                        <h2 class="accordion-header" id="flush-headingTwo">
-                            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#flush-collapseTwo" aria-expanded="false" aria-controls="flush-collapseTwo">
-                                Legacy Scans from /u/LecpisMagna
-                            </button>
-                        </h2>
-                        <div id="flush-collapseTwo" class="accordion-collapse collapse" aria-labelledby="flush-headingTwo" data-bs-parent="#accordionFlushExample">
-                            <div class="accordion-body">
-                                <p>
-                                    This is the original set of scans used by Proxy Nexus. MPC files have a simple black border added around the card to serve as a bleed. There are two different ways a border is added.
-                                </p>
-                                <h5>Scaled</h5>
-                                <p>
-                                    The shortest dimension of the original scans is resized and scaled by 1.5% past MPC's cut line. This should help minimize most black lines along the edge of cards but may result a small loss of the original graphic. Choose this option to help avoid any black lines/borders along the edge of the cards.
-                                </p>
-                                <h5>Fit</h5>
-                                <p>
-                                    Fits the scans within MPC's cut line. May result in black lines along the edges of the card. Choose this option to avoid any loss of the scanned image.
-                                </p>
-                                <p>
-                                    <strong>Fit is the default option,</strong> but can be changed on the settings page. For anyone interested in the technical details, the images were produced with this Python script: <a href="https://github.com/axmccx/proxynexus/tree/master/misc/v1/borderGenerator.py" target="_blank" rel="noopener">borderGenerator.py</a>
-                                </p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+                
                 <br/>
-                <p>The zip file Proxy Nexus provides contains:</p>
+                <!-- <p>The zip file Proxy Nexus provides contains:</p>
                 <ul>
                     <li>Corp images</li>
                     <li>Runner images</li>
@@ -138,18 +96,18 @@
                 </ul>
                 <p>
                     <strong>Note: Files that end with 'back' are the back side art image for the file with the similar name. </strong> Eg. 09001_pt_pdf_back.jpg is the back side art image for 09001_pt_pdf.jpg. For step 12 below, be sure to select "Different images" for the card backs, in order to include these images if desired.
-                </p>
+                </p> -->
                 <h4>How to make an MPC order</h4>
                 <ol>
                     <li>Download the zip file from Proxy Nexus.</li>
                     <li>Extract the zip file.</li>
                     <li>Visit <a href="https://www.makeplayingcards.com/design/custom-blank-card.html" target="_blank" rel="noopener">Custom Game Cards (63 x 88mm)</a> page to get started with a new project.</li>
                     <li>Choose the card stock, either "(S30) Standard Smooth" or "(S33) Superior Smooth" are good choices. </li>
-                    <li>Chose the deck size. <br /> <strong>Note:</strong> <i>Large orders, e.g. a single System Core 2019 Set, contains 255 cards. The MPC option that fits this size is 396, which costs $69.05 USD. It would be easier to setup and possibly cheaper to split the order into a Corp and Runner deck. (Hence why the files are separated in the zip file). The Corp deck would contain 144 cards, and the Runner deck would contain 111 cards. This would cost $27.90 USD + $24.95 USD = $52.85 USD.</i></li>
+                    <li>Chose the deck size.</li>
                     <li>Click the red "start your design" button.</li>
                     <li>Enter the exact card count for the deck and click the blue "Different images" button for the card fronts.</li>
-                    <li>Click the red "Upload images" button near the top right and<strong> select all the images</strong> in either the corp or runner folder from the extracted zip file. If printing all the cards in one deck, repeat this step with the other folder from the zip file.</li>
-                    <li>Once all the images have finished uploading, <a href="https://i.imgur.com/CN5FStf.png" target="_blank" rel="noopener">click the "Help me autofill images!" button.</a> Or simply drag and drop all the images to the cards on the left. <u>If the deck is a mix of corp and runner cards,</u> take note of the <strong>Side</strong> (corp or runner) of each card number.</li>
+                    <li>Click the red "Upload images" button near the top right and<strong> select all the images</strong></li>
+                    <li>Once all the images have finished uploading, <a href="https://i.imgur.com/CN5FStf.png" target="_blank" rel="noopener">click the "Help me autofill images!" button.</a> Or simply drag and drop all the images to the cards on the left.</li>
                     <li>Once all the images have been placed, click the "Next Step" button at the top right of the screen.</li>
                     <li>Click "Next Step" again, since I assume you're not adding text to the front of the cards.</li>
                     <li>This step depends on whether the deck is entire one side, or a mix of the two. If the deck is a mix of the two, select "Different images" for the card backs. Otherwise, select "Same Image".</li>

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -271,7 +271,7 @@ class CardManager {
   updateCardListFromTextArea(cardListText) {
     const input = cardListText.split(/\n/).filter((e) => (e !== ''));
     const cardInputRegex = /([0-9] |[0-9]x )?(.*)/;
-    const cardTitles = Object.values(this.cards).map((c) => c.label);
+    const cardTitles = Object.values(this.cards).map((c) => c.title);
     const newCardTitles = [];
     const unfoundCards = [];
     let unfoundCount = 0;


### PR DESCRIPTION
Picked this up today after neglecting it for a while.

Changes:
- Fix a big bug with how the text area updates happen.  Before, you'd hit a key and a bunch of extra copies of the existing cards get added, it doesn't do that anymore.  Also, I confirmed entering input like "3 Robb Stark (Core)" or "2x Arya Stark (Core)" works as expected.
- Remove links to a few pages (statistics, about).  We don't need them for an mvp.  I kept the source though so the links might still work if you enter the url manually, just in case we need them later.
- Remove the netrunnerdb link support section - might add a thronesdb link later, but I think copy/paste from there is fine for an mvp